### PR TITLE
Hotfix/getparam error

### DIFF
--- a/util/sandbox/scripts/draft-list/getparam.js
+++ b/util/sandbox/scripts/draft-list/getparam.js
@@ -1,26 +1,11 @@
 /*
 下書き一覧でパラメータを解析するスクリプト
  */
-//親ページのURLを解析する
-var PageSetting = new Object();
-PageSetting.getParent = true;
-PageSetting.currentParam = decodeURIExtension(document.referrer);
-if (!PageSetting.currentParam) {
-    PageSetting.currentParam = "http://scp-jp-sandbox3.wikidot.com/draft-list";
-}
-PageSetting.myPage = (function () {
-    var tmpURL = PageSetting.currentParam.split("http://").join("").split("/");
-    return "http://" + tmpURL[0] + "/" + tmpURL[1];
-})();
-PageSetting.currentParam = PageSetting.currentParam.split(PageSetting.myPage).join("");
-PageSetting.OrderParam = "";
-if (PageSetting.currentParam.indexOf("/order/") >= 0) {
-    PageSetting.OrderParam = PageSetting.currentParam.substring(PageSetting.currentParam.indexOf("/order/"), PageSetting.currentParam.length);
-}
+
 //親ページのURLを解析する
 var PageSetting = new Object();
 PageSetting.currentParam = decodeURIExtension(document.referrer);
-if (!PageSetting.currentParam) {
+if ((!PageSetting.currentParam)||(new URL(PageSetting.currentParam).pathname.length<=1)) {
     PageSetting.currentParam = "http://scp-jp-sandbox3.wikidot.com/draft-list";
     PageSetting.getParent = false;
 }

--- a/util/sandbox/scripts/draft-list/getparam.js
+++ b/util/sandbox/scripts/draft-list/getparam.js
@@ -1,9 +1,9 @@
 /*
 下書き一覧でパラメータを解析するスクリプト
  */
-
 //親ページのURLを解析する
 var PageSetting = new Object();
+PageSetting.getParent = true;
 PageSetting.currentParam = decodeURIExtension(document.referrer);
 if ((!PageSetting.currentParam)||(new URL(PageSetting.currentParam).pathname.length<=1)) {
     PageSetting.currentParam = "http://scp-jp-sandbox3.wikidot.com/draft-list";


### PR DESCRIPTION
SB3で現在発生している並び替え URL生成のバグ修正．

- 重複の削除
- URL修正条件の追加

 [ITP (Full Third-Party Cookie Blocking and More)](https://webkit.org/blog/10218/full-third-party-cookie-blocking-and-more/)により，iOSでのブラウザ全て，MacOSのSafariでreferrerがドメインレベルのみ取得になるため，
```PageSetting.currentParam```が取得はできるもののドメインレベル以下が存在しないためにdraft-listに飛べなくなっていた．
その為，URLオブジェクトでpathnameが存在するかどうかの条件を追加した．
