### PR TITLE
[fix] sotm-theme: fix-credit-module-layout

### DIFF
--- a/theme/sotm/style0.css
+++ b/theme/sotm/style0.css
@@ -435,3 +435,9 @@ div.page-rate-widget-box .rate-points {
 #side-bar .side-block .collapsible-block-folded a.collapsible-block-link::before {
   background: url("http://scp-jp.wikidot.com/local--files/nav:side/expand.png") 0 2px no-repeat;
 }
+
+/* creditモジュールの表示崩れを修正 */
+.creditRate.creditModule .page-rate-widget-box {
+  margin-bottom: unset;
+  margin-right: unset;
+}


### PR DESCRIPTION
クレジットモジュールの表示崩れを修正

![image](https://github.com/SCP-JP/files/assets/47080593/c47a8b35-7c91-4f91-a1fd-94abe39dec52)
![image](https://github.com/SCP-JP/files/assets/47080593/1a6bc59e-e260-4c23-8187-0e060c766689)
